### PR TITLE
Update RooAbsReal.h

### DIFF
--- a/roofit/roofitcore/inc/RooAbsReal.h
+++ b/roofit/roofitcore/inc/RooAbsReal.h
@@ -386,7 +386,7 @@ protected:
   RooPlot* plotOnWithErrorBand(RooPlot* frame,const RooFitResult& fr, Double_t Z, const RooArgSet* params, const RooLinkedList& argList, Bool_t method1) const ;
 
   // Support interface for subclasses to advertise their analytic integration
-  // and generator capabilities in their analticalIntegral() and generateEvent()
+  // and generator capabilities in their analyticalIntegral() and generateEvent()
   // implementations.
   Bool_t matchArgs(const RooArgSet& allDeps, RooArgSet& numDeps, 
 		   const RooArgProxy& a) const ;


### PR DESCRIPTION
spell mistake  of word ( Analytical) is solved in line 389 of  root/roofit/roofitcore/inc/RooAbsReal.h

![se](https://user-images.githubusercontent.com/73425223/103886165-1b535880-5107-11eb-834d-d10de0e31e10.png)
